### PR TITLE
KB-11554 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the cb-service-registry service.

### DIFF
--- a/src/main/java/com/igot/service_locator/config/BeanConfiguration.java
+++ b/src/main/java/com/igot/service_locator/config/BeanConfiguration.java
@@ -1,6 +1,8 @@
 package com.igot.service_locator.config;
 
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -17,7 +19,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
@@ -47,14 +48,17 @@ public class BeanConfiguration {
         int connectionRequestTimeoutMs = 2000;
         int responseTimeoutMs = 45000;
         RequestConfig config = RequestConfig.custom().
-                setConnectTimeout(Timeout.ofMilliseconds(connectTimeoutMs)).
                 setConnectionRequestTimeout(Timeout.ofMilliseconds(connectionRequestTimeoutMs)).
                 setResponseTimeout(Timeout.ofMilliseconds(responseTimeoutMs)).
                 build();
 
-        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setMaxTotal(2000);
-        connectionManager.setDefaultMaxPerRoute(500);
+        PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                .setDefaultConnectionConfig(ConnectionConfig.custom()
+                        .setConnectTimeout(Timeout.ofMilliseconds(connectTimeoutMs))
+                        .build())
+                .setMaxConnTotal(2000)
+                .setMaxConnPerRoute(500)
+                .build();
 
         CloseableHttpClient client = HttpClients.custom()
                 .setDefaultRequestConfig(config)

--- a/src/main/java/com/igot/service_locator/exceptions/RestExceptionHandling.java
+++ b/src/main/java/com/igot/service_locator/exceptions/RestExceptionHandling.java
@@ -18,11 +18,13 @@ public class RestExceptionHandling {
         ErrorResponse errorResponse = null;
         if (ex instanceof CustomException) {
             CustomException CustomException = (com.igot.service_locator.exceptions.CustomException) ex;
-            status = HttpStatus.BAD_REQUEST;
+            HttpStatus customStatus = HttpStatus.BAD_REQUEST;
             // Check if the CustomException provides an HTTP status code
             if (CustomException != null) {
                 try {
-                    status = CustomException.getHttpStatusCode();
+                    if (CustomException.getHttpStatusCode() != null) {
+                        customStatus = CustomException.getHttpStatusCode();
+                    }
                 } catch (IllegalArgumentException e) {
                     log.warn("Invalid HTTP status code provided in CustomException: " + CustomException.getHttpStatusCode());
                 }
@@ -30,18 +32,13 @@ public class RestExceptionHandling {
             errorResponse = ErrorResponse.builder()
                     .code(CustomException.getCode())
                     .message(CustomException.getMessage())
-                    .httpStatusCode(CustomException.getHttpStatusCode() != null
-                            ? CustomException.getHttpStatusCode().value()
-                            : HttpStatus.BAD_REQUEST.value())
+                    .httpStatusCode(customStatus.value())
                     .build();
             if (StringUtils.isNotBlank(CustomException.getMessage())) {
                 log.error(CustomException.getMessage());
             }
 
-            return new ResponseEntity<>(errorResponse,
-                    CustomException.getHttpStatusCode() != null
-                            ? CustomException.getHttpStatusCode()
-                            : HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(errorResponse, customStatus);
         }
         errorResponse = ErrorResponse.builder()
                 .code("ERROR")


### PR DESCRIPTION
1. Remove this use of "setConnectTimeout"; it is deprecated.
2. Remove this useless assignment to local variable "status".